### PR TITLE
fix: Updates super admin role as Editor

### DIFF
--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -1,6 +1,6 @@
 import type { RoleMapping } from "../types/auth";
 
 export const ROLE_MAPPING: RoleMapping = {
-  super_admin: "Administrator",
+  super_admin: "Editor",
   editor: "Editor",
 };


### PR DESCRIPTION
Updates the `super_admin` role mapping to align with the intended functionality. The role is changed from "Administrator" to "Editor", ensuring a more accurate representation of the role's permissions and responsibilities.